### PR TITLE
Feature/fix safe area

### DIFF
--- a/Sources/KeyboardSupport/KeyboardRespondable.swift
+++ b/Sources/KeyboardSupport/KeyboardRespondable.swift
@@ -113,7 +113,6 @@ public extension KeyboardScrollable where Self: UIViewController {
         
         var mutableInset = contentInset
         if #available(iOS 11.0, *) {
-            print(view.safeAreaInsets.bottom)
             mutableInset.bottom += keyboardSize.height - view.safeAreaInsets.bottom
         } else {
             mutableInset.bottom += keyboardSize.height

--- a/Sources/KeyboardSupport/KeyboardRespondable.swift
+++ b/Sources/KeyboardSupport/KeyboardRespondable.swift
@@ -114,9 +114,9 @@ public extension KeyboardScrollable where Self: UIViewController {
         var mutableInset = contentInset
         if #available(iOS 11.0, *) {
             print(view.safeAreaInsets.bottom)
-            mutableInset.bottom += keyboardSize.height - view.safeAreaInsets.bottom
+            mutableInset.bottom += 200
         } else {
-            mutableInset.bottom += keyboardSize.height
+            mutableInset.bottom += 200
         }
         adjustScrollViewInset(mutableInset)
         

--- a/Sources/KeyboardSupport/KeyboardRespondable.swift
+++ b/Sources/KeyboardSupport/KeyboardRespondable.swift
@@ -114,9 +114,9 @@ public extension KeyboardScrollable where Self: UIViewController {
         var mutableInset = contentInset
         if #available(iOS 11.0, *) {
             print(view.safeAreaInsets.bottom)
-            mutableInset.bottom += 200
+            mutableInset.bottom += keyboardSize.height - view.safeAreaInsets.bottom
         } else {
-            mutableInset.bottom += 200
+            mutableInset.bottom += keyboardSize.height
         }
         adjustScrollViewInset(mutableInset)
         

--- a/Sources/KeyboardSupport/KeyboardRespondable.swift
+++ b/Sources/KeyboardSupport/KeyboardRespondable.swift
@@ -112,7 +112,12 @@ public extension KeyboardScrollable where Self: UIViewController {
         let keyboardSize = keyboardInfo.finalFrame.size
         
         var mutableInset = contentInset
-        mutableInset.bottom += keyboardSize.height
+        if #available(iOS 11.0, *) {
+            print(view.safeAreaInsets.bottom)
+            mutableInset.bottom += keyboardSize.height - view.safeAreaInsets.bottom
+        } else {
+            mutableInset.bottom += keyboardSize.height
+        }
         adjustScrollViewInset(mutableInset)
         
         // If active text field is hidden by keyboard, scroll so it's visible


### PR DESCRIPTION
Subtracts the Safe Area bottom inset when calculating additional bottom inset since the keyboard frame encompasses the safe area and scroll views' insets are typically automatically adjusted to account for safe area.