### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class ViewController: UIViewController, KeyboardDismissable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupKeyboardDismissal()
+        setupKeyboardDismissalView()
     }
 }
 ```


### PR DESCRIPTION
Renamed `setupKeyboardDismissal()` --> `setupKeyboardDismissalView()` to match the protocol definition.