### PR TITLE
CGRect conversion produces incorrect results for text field frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ##### Enhancements
 
+* None
+
+##### Bug Fixes
+
+* Addressed issue where scrolling to the focused text field would not work properly.
+[Daniel Larsen](https://github.com/grandlarseny)
+[#48](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/48)
+
+## 2.1.1 (2020-01-16)
+
+##### Enhancements
+
 * Added Carthage support.
 [Ryan Gant](https://github.com/ganttastic)
 [#46](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,15 @@
 
 ##### Enhancements
 
-* None
-
-##### Bug Fixes
-
-* Addressed issue where scrolling to the focused text field would not work properly.
-[Daniel Larsen](https://github.com/grandlarseny)
-[#48](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/48)
-
-## 2.1.1 (2020-01-16)
-
-##### Enhancements
-
 * Added Carthage support.
 [Ryan Gant](https://github.com/ganttastic)
 [#46](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/46)
 
 ##### Bug Fixes
 
-* None
+* Addressed issue where scrolling to the focused text field would not work properly.
+[Daniel Larsen](https://github.com/grandlarseny)
+[#48](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/48)
 
 ## 2.1.0 (2019-04-30)
 

--- a/Sources/KeyboardSupport/KeyboardScrollable.swift
+++ b/Sources/KeyboardSupport/KeyboardScrollable.swift
@@ -162,7 +162,7 @@ public extension KeyboardScrollable where Self: UIViewController {
             scrollToSelectedText(for: textView, keyboardInfo: keyboardInfo)
         } else {
             let preferredPaddingAroundInput = (firstResponder as? KeyboardPaddingProviding)?.inputPadding ?? .zero
-            scrollToRectIfNecessary(rect: firstResponder.frame, of: firstResponder, keyboardInfo: keyboardInfo, preferredPaddingAroundInput: preferredPaddingAroundInput)
+            scrollToRectIfNecessary(rect: firstResponder.bounds, of: firstResponder, keyboardInfo: keyboardInfo, preferredPaddingAroundInput: preferredPaddingAroundInput)
         }
     }
     


### PR DESCRIPTION
I just ran into an issue where scrolling to text fields is failing pretty hard. The core of the issue is that when converting the text field's CGRect to the containing scroll view, the bounds should be used instead of the frame. To be honest, I'm not sure how this hasn't caused issues before, which makes me worry that this could be a breaking change. 

All I know is that it intellectually makes sense that this should use `bounds` for the rect conversion and it has definitely fixed the scrolling issue in my app.

Here's a screenshot of the behavior I described:
<img width="910" alt="image" src="https://user-images.githubusercontent.com/583988/72456879-2214ed00-378b-11ea-8407-c2c64d3c5263.png">
