### PR TITLE
Allow the original content insets to be set after setting up the keyboard observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None
+* Allowed setting the originalContentInsets before and after setting up the kyboard observers in KeyboardScrollable. This allows us to do things like setting content insets in viewDidLayoutSubviews() and such
+[Fernando Arocho](https://github.com/Specialist17)
+[#57](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/57)
 
 ## 2.1.1 (2020-01-16)
 

--- a/KeyboardSupport.xcodeproj/project.pbxproj
+++ b/KeyboardSupport.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -667,7 +667,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/KeyboardSupport.xcodeproj/project.pbxproj
+++ b/KeyboardSupport.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -667,7 +667,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/KeyboardSupport/KeyboardScrollable.swift
+++ b/Sources/KeyboardSupport/KeyboardScrollable.swift
@@ -88,7 +88,8 @@ public extension KeyboardScrollable where Self: UIViewController {
     var preservesContentInsetWhenKeyboardVisible: Bool { return true }
     
     func setupKeyboardObservers() {
-        keyboardScrollableScrollView?.originalContentInset = keyboardScrollableScrollView?.contentInset
+        
+        keyboardScrollableScrollView?.originalContentInset = keyboardScrollableScrollView?.adjustedContentInset
         
         let keyboardWillShowNotificationName: Notification.Name = {
             #if swift(>=4.2)
@@ -196,7 +197,7 @@ public extension KeyboardScrollable where Self: UIViewController {
     
     private func resetViewForKeyboardDisappearance(with keyboardInfo: KeyboardInfo) {
         guard let scrollView = keyboardScrollableScrollView else { return }
-        let originalContentInset = scrollView.originalContentInset ?? .zero
+        let originalContentInset = scrollView.originalContentInset ?? scrollView.adjustedContentInset
         adjustScrollViewInset(originalContentInset, keyboardInfo: keyboardInfo)
     }
     

--- a/Sources/KeyboardSupport/KeyboardScrollable.swift
+++ b/Sources/KeyboardSupport/KeyboardScrollable.swift
@@ -88,9 +88,6 @@ public extension KeyboardScrollable where Self: UIViewController {
     var preservesContentInsetWhenKeyboardVisible: Bool { return true }
     
     func setupKeyboardObservers() {
-        
-        keyboardScrollableScrollView?.originalContentInset = keyboardScrollableScrollView?.adjustedContentInset
-        
         let keyboardWillShowNotificationName: Notification.Name = {
             #if swift(>=4.2)
             return UIResponder.keyboardWillShowNotification
@@ -108,6 +105,10 @@ public extension KeyboardScrollable where Self: UIViewController {
         
         keyboardWillShowObserver = NotificationCenter.default.addObserver(forName: keyboardWillShowNotificationName, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             guard let keyboardInfo = KeyboardInfo(notification: notification), let activeField = self?.view.activeFirstResponder() else { return }
+            if self?.keyboardScrollableScrollView?.originalContentInset == nil {
+                self?.keyboardScrollableScrollView?.originalContentInset = self?.keyboardScrollableScrollView?.adjustedContentInset
+            }
+
             self?.adjustViewForKeyboardAppearance(with: keyboardInfo, firstResponder: activeField)
             self?.keyboardWillShow(keyboardInfo: keyboardInfo)
         })
@@ -197,7 +198,7 @@ public extension KeyboardScrollable where Self: UIViewController {
     
     private func resetViewForKeyboardDisappearance(with keyboardInfo: KeyboardInfo) {
         guard let scrollView = keyboardScrollableScrollView else { return }
-        let originalContentInset = scrollView.originalContentInset ?? scrollView.adjustedContentInset
+        let originalContentInset = scrollView.originalContentInset ?? .zero
         adjustScrollViewInset(originalContentInset, keyboardInfo: keyboardInfo)
     }
     

--- a/Sources/KeyboardSupport/KeyboardScrollable.swift
+++ b/Sources/KeyboardSupport/KeyboardScrollable.swift
@@ -106,7 +106,7 @@ public extension KeyboardScrollable where Self: UIViewController {
         keyboardWillShowObserver = NotificationCenter.default.addObserver(forName: keyboardWillShowNotificationName, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             guard let keyboardInfo = KeyboardInfo(notification: notification), let activeField = self?.view.activeFirstResponder() else { return }
             if self?.keyboardScrollableScrollView?.originalContentInset == nil {
-                self?.keyboardScrollableScrollView?.originalContentInset = self?.keyboardScrollableScrollView?.adjustedContentInset
+                self?.keyboardScrollableScrollView?.originalContentInset = self?.keyboardScrollableScrollView?.contentInset
             }
 
             self?.adjustViewForKeyboardAppearance(with: keyboardInfo, firstResponder: activeField)


### PR DESCRIPTION
Came across a case where we needed to set the insets in a `viewDidLayoutSubviews()` and we were setting the originalContentInset on the `setupKeyboardObservers()` which is convention to call on `viewWillAppear()`. 
Since `viewWillAppear()`gets called before `viewDidLayoutSubviews()`, we were setting this to nil:
`keyboardScrollableScrollView?.originalContentInset = keyboardScrollableScrollView?.contentInset`
 
This change sets the originalContentInset only when we prompt the keyboard to show and only does if we haven't set it before, or `keyboardScrollableScrollView?.originalContentInset == nil`

Also bumped up the deployment target but that can be reverted if necessary