### PR TITLE
Only update contentInset if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ##### Bug Fixes
 
- * Only update contentInset if the new insets are different from the existing insets. This avoids triggering unnecessary table/collectionview reloads.
- [Dimitar Milinski](https://github.com/dmilinski08)
+* Only update contentInset if the new insets are different from the existing insets. This avoids triggering unnecessary table/collectionview reloads.
+[Dimitar Milinski](https://github.com/dmilinski08)
 [#62](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/62)
 
 ## 2.1.2 (2020-12-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Bug Fixes
 
-* None
+ * Only update contentInset if the new insets are different from the existing insets. This avoids triggering unnecessary table/collectionview reloads.
+ [Dimitar Milinski](https://github.com/dmilinski08)
+[#62](https://github.com/BottleRocketStudios/iOS-KeyboardSupport/pull/62)
 
 ## 2.1.2 (2020-12-09)
 

--- a/Sources/KeyboardSupport/KeyboardScrollable.swift
+++ b/Sources/KeyboardSupport/KeyboardScrollable.swift
@@ -212,8 +212,12 @@ public extension KeyboardScrollable where Self: UIViewController {
     
     private func adjustScrollViewInset(_ inset: UIEdgeInsets, keyboardInfo: KeyboardInfo) {
         UIView.animate(withDuration: keyboardInfo.animationDuration, delay: 0, options: [UIView.AnimationOptions(rawValue: keyboardInfo.animationCurve)], animations: {
-            self.keyboardScrollableScrollView?.contentInset = inset
-            self.keyboardScrollableScrollView?.scrollIndicatorInsets = inset
+            if self.keyboardScrollableScrollView?.contentInset != inset {
+                self.keyboardScrollableScrollView?.contentInset = inset
+            }
+            if self.keyboardScrollableScrollView?.scrollIndicatorInsets != inset {
+                self.keyboardScrollableScrollView?.scrollIndicatorInsets = inset
+            }
         }, completion: nil)
     }
 }


### PR DESCRIPTION
Only update contentInset if the new insets are different from the existing insets. This avoids triggering unnecessary table/collectionview reloads.